### PR TITLE
Update predict.py

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -129,7 +129,7 @@ def predict():
         for output in outputs:
             prediction = tokenizer.decode(output, skip_special_tokens=True)
             response = re.split(r"Response:\s*", prediction)[-1]
-            result.append(response)
+            result.append(response.replace("\n", ""))
         print(result)
         print(idx)
     return args.dataset, result


### PR DESCRIPTION
The dev_gold.sql, ground_truths are seperated by "\n". So if a sql contents "\n" it would be considered as more than one responses in the official spider evaluating demo.
This change should be able to handle this bug.